### PR TITLE
priority color indication for opened issues. assigned to me and not assigned filters

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -4,13 +4,14 @@ class DashboardController < ApplicationController
   def index
     @use_drop_down_menu = Setting.plugin_dashboard['use_drop_down_menu']
     @selected_project_id = params[:project_id].nil? ? -1 : params[:project_id].to_i
+    @assigned_to = params[:assigned_to].nil? ? "" : params[:assigned_to]
     show_sub_tasks = Setting.plugin_dashboard['display_child_projects_tasks']
     @show_project_badge = @selected_project_id == -1 || @selected_project_id != -1 && show_sub_tasks
     @use_drag_and_drop = Setting.plugin_dashboard['enable_drag_and_drop']
     @display_minimized_closed_issue_cards = Setting.plugin_dashboard['display_closed_statuses'] ? Setting.plugin_dashboard['display_minimized_closed_issue_cards'] : false
     @statuses = get_statuses
     @projects = get_projects
-    @issues = get_issues(@selected_project_id, show_sub_tasks)
+    @issues = get_issues(@selected_project_id, show_sub_tasks, @assigned_to)
   end
 
   def set_issue_status
@@ -66,7 +67,7 @@ class DashboardController < ApplicationController
     end
   end
 
-  def get_issues(project_id, with_sub_tasks)
+  def get_issues(project_id, with_sub_tasks, assigned_to)
     id_array = []
 
     if project_id != -1
@@ -80,6 +81,12 @@ class DashboardController < ApplicationController
     end
 
     items = id_array.empty? ? Issue.visible : Issue.visible.where(:projects => {:id => id_array})
+
+    if (assigned_to == "me")
+      items = items.visible.where(assigned_to_id: User.current.id)
+    elsif (assigned_to == "no_one")
+      items = items.visible.where(assigned_to_id: nil)
+    end
 
     unless Setting.plugin_dashboard['display_closed_statuses']
       items = items.open

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -89,6 +89,7 @@ class DashboardController < ApplicationController
       {
         :id => item.id,
         :subject => item.subject,
+        :priority => item.priority,
         :status_id => item.status.id,
         :project_id => item.project.id,
         :created_on => item.created_on,

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -15,6 +15,12 @@
 			<% end %>
 		<% end %>
 	</select>
+
+	<input type="checkbox" id="assigned_to_me" name="assigned_to_me" <%= @assigned_to == 'me' ? 'checked' : '' %>/>
+	<label for="assigned_to_me"><%=l :assigned_to_me %></label>
+
+	<input type="checkbox" id="not_assigned" name="not_assigned" <%= @assigned_to == 'no_one' ? 'checked' : '' %>/>
+	<label for="not_assigned"><%=l :not_assigned %></label>
 <% else %>
 	<div class="select_project_container">
 		<% @projects.each do |project_id, project| %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -37,7 +37,7 @@
 				<% @issues.select { |issue| issue[:status_id] == status_id }.each do |issue| %>
 					<% project_color = @projects[issue[:project_id]][:color] %>
 					<% project_name = @projects[issue[:project_id]][:name] %>
-					<div class="issue_card" style="border-color: <%= project_color %>" data-id="<%= issue[:id] %>" onclick="goToIssue(<%= issue[:id] %>)">
+					<div class="issue_card issue_card_priority_<%= issue[:priority] %>" style="border-color: <%= project_color %>" data-id="<%= issue[:id] %>" onclick="goToIssue(<%= issue[:id] %>)">
 						<span class="issue_card_id"> <%= "#" + issue[:id].to_s %> </span>
 						<div class="issue_card_header">
 							<span class="issue_card_header_date"><%= I18n.l(issue[:created_on], format: :long) %></span>

--- a/assets/javascripts/script.js
+++ b/assets/javascripts/script.js
@@ -20,11 +20,13 @@ function goToIssue(id) {
 }
 
 function chooseProject(projectId) {
+    const params = new URLSearchParams(window.location.search);
     if (projectId == "-1") {
-        location.search = "";
+        params.delete('project_id');
     } else {
-        location.search = `project_id=${projectId}`;   
+        params.set('project_id', projectId);
     }
+    location.search = params.toString();
 }
 
 async function setIssueStatus(issueId, statusId, item, oldContainer, oldIndex) { 
@@ -41,6 +43,26 @@ function init(useDragAndDrop) {
         item.addEventListener('click', function() {
             chooseProject(this.dataset.id);
         })
+    });
+
+    document.querySelector('#assigned_to_me')?.addEventListener('change', function () {
+        const params = new URLSearchParams(window.location.search);
+        if (this.checked) {
+            params.set('assigned_to', "me");
+        }else{
+            params.delete('assigned_to');
+        }
+        location.search = params.toString();
+    });
+
+    document.querySelector('#not_assigned')?.addEventListener('change', function () {
+        const params = new URLSearchParams(window.location.search);
+        if (this.checked) {
+            params.set('assigned_to', "no_one");
+        }else{
+            params.delete('assigned_to');
+        }
+        location.search = params.toString();
     });
 
     const projectsSelector = document.querySelector('#select_project');

--- a/assets/stylesheets/style.css
+++ b/assets/stylesheets/style.css
@@ -198,3 +198,31 @@
 .status_column_issues .issue_card .issue_card_id {
     display: none;
 }
+
+/* priority color border on the left side of the issue */
+/* used same colors from https: //github.com/jgraichen/redmine_dashboard */
+.status_column_issues .issue_card {
+	--border-color: transparent;
+	border-left: 5px solid black;
+	border-color: var(--border-color);
+}
+
+.status_column_issues .issue_card.issue_card_priority_Low {
+	--border-color: rgb(170, 170, 170);
+}
+
+.status_column_issues .issue_card.issue_card_priority_Normal {
+	--border-color: rgb(102, 187, 102);
+}
+
+.status_column_issues .issue_card.issue_card_priority_High {
+	--border-color: rgb(255, 165, 0);
+}
+
+.status_column_issues .issue_card.issue_card_priority_Urgent {
+	--border-color: rgb(255, 0, 0);
+}
+
+.status_column_issues .issue_card.issue_card_priority_Immediate {
+	--border-color: rgb(0, 0, 0);
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,3 +11,5 @@ en:
   settings_generate_colors: "Generate colors"
   executor_not_set: "Not set"
   label_all: "All"
+  assigned_to_me: "Assigned to me"
+  not_assigned: "Not assigned"

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -11,3 +11,5 @@ hr:
   settings_generate_colors: "Generiraj boje"
   executor_not_set: "Nije postavljen"
   label_all: "Svi"
+  assigned_to_me: "Dodijeljen meni"
+  not_assigned: "Nije dodijeljeno"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -11,3 +11,5 @@ pl:
   settings_generate_colors: "Wygeneruj kolory"
   executor_not_set: "Nie przydzielono"
   label_all: "Wszystkie"
+  assigned_to_me: "Przydzielony do mnie"
+  not_assigned: "Nie przypisano"

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -11,3 +11,5 @@ pt_BR:
   settings_generate_colors: "Gerar as cores"
   executor_not_set: "Não definido"
   label_all: "Todos"
+  assigned_to_me: "Atribuído a mim"
+  not_assigned: "Não atribuído"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -11,3 +11,5 @@ ru:
   settings_generate_colors: "Сгенерировать цвета"
   executor_not_set: "Не установлен"
   label_all: "Все"
+  assigned_to_me: "Назначено мне"
+  not_assigned: "Не назначено"


### PR DESCRIPTION
I really like priority color indication from [redmine_dashboard plugin](https://github.com/jgraichen/redmine_dashboard), so I've took colors they used and add them to your plugin.

Add 'Assigned to me' checkbox to view only my issues, cause it's usually what developers are needed.
Add 'Not assigned' checkbox to view issues that not yet assigned. Really useful when you need to pick next task or for manager to control tasks.
Checkboxes available only for @use_drop_down_menu

Tested in redmine 5.0.5

How it looks:
![image](https://github.com/akpaevj/dashboard/assets/680417/524f9e26-1fae-48ea-bf74-7aac24d1ae6f)
Have to hide sensitive information on screenshot

