### PR TITLE
Add feature Display only issues in "open" status projects

### DIFF
--- a/app/views/settings/_dashboard_settings.erb
+++ b/app/views/settings/_dashboard_settings.erb
@@ -66,5 +66,11 @@
       <%= check_box_tag "settings[display_child_projects_tasks]", false, @settings['display_child_projects_tasks'] %>
     </td>
   </tr>
+  <tr>
+    <td> <%=l :settings_display_open_projects_only %> </th>
+    <td>
+      <%= check_box_tag "settings[display_open_projects_only]", false, @settings['display_open_projects_only'] %>
+    </td>
+  </tr>
   </tbody>
 </table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,9 +3,10 @@ en:
   settings_header_statuses: "Statuses colors"
   settings_header_projects: "Projects colors"
   settings_header_other: "Other"
-  settings_use_drop_down_menu: 'Use drop-down menu for the project choosing'
+  settings_use_drop_down_menu: "Use drop-down menu for the project choosing"
   settings_display_closed_statuses: 'Display "closed" statuses'
-  settings_display_child_projects_tasks: 'Display child projects tasks'
+  settings_display_child_projects_tasks: "Display child projects tasks"
+  settings_display_open_projects_only: 'Display only projects with status "open"'
   settings_display_minimized_closed_issue_cards: 'Display minimized "closed" issue cards'
   settings_enable_drag_and_drop: '"Drag and drop" status changing'
   settings_generate_colors: "Generate colors"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -3,11 +3,12 @@ fr:
   settings_header_statuses: "Couleurs des status"
   settings_header_projects: "Couleurs des projets"
   settings_header_other: "Autre"
-  settings_use_drop_down_menu: 'Utiliser le menu déroulant pour choisir le projet'
-  settings_display_closed_statuses: 'Afficher le status « closed »'
-  settings_display_child_projects_tasks: 'Afficher les tâches de sous-projets'
-  settings_display_minimized_closed_issue_cards: 'Afficher les cartes « closed » en minimisé'
-  settings_enable_drag_and_drop: 'Changer de status par glisser-déposer'
+  settings_use_drop_down_menu: "Utiliser le menu déroulant pour choisir le projet"
+  settings_display_closed_statuses: "Afficher le status « closed »"
+  settings_display_child_projects_tasks: "Afficher les tâches de sous-projets"
+  settings_display_open_projects_only: "Afficher uniquement les projets avec le statut « ouvert »"
+  settings_display_minimized_closed_issue_cards: "Afficher les cartes « closed » en minimisé"
+  settings_enable_drag_and_drop: "Changer de status par glisser-déposer"
   settings_generate_colors: "Générer les couleurs"
   executor_not_set: "Pas encore défini"
   label_all: "Tous"

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -3,10 +3,11 @@ hr:
   settings_header_statuses: "Boje statusa"
   settings_header_projects: "Boje projekata"
   settings_header_other: "Ostale postavke"
-  settings_use_drop_down_menu: 'Koristi padajući izbornik za odabir projekata'
-  settings_display_closed_statuses: 'Prikaži zatvorene predmete'
-  settings_display_child_projects_tasks: 'Prikaži ugniježdene predmete'
-  settings_display_minimized_closed_issue_cards: 'Prikaži zatvorene predmete minimizirane'
+  settings_use_drop_down_menu: "Koristi padajući izbornik za odabir projekata"
+  settings_display_closed_statuses: "Prikaži zatvorene predmete"
+  settings_display_child_projects_tasks: "Prikaži ugniježdene predmete"
+  settings_display_open_projects_only: 'Prikaži samo projekte sa statusom "otvoreno"'
+  settings_display_minimized_closed_issue_cards: "Prikaži zatvorene predmete minimizirane"
   settings_enable_drag_and_drop: 'Dozvoli "Drag and drop" izmjenu statusa'
   settings_generate_colors: "Generiraj boje"
   executor_not_set: "Nije postavljen"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -3,9 +3,10 @@ pl:
   settings_header_statuses: "Kolory statusów"
   settings_header_projects: "Kolory projektów"
   settings_header_other: "Inne"
-  settings_use_drop_down_menu: 'Użycie menu typu drop-down do wyboru projektów'
+  settings_use_drop_down_menu: "Użycie menu typu drop-down do wyboru projektów"
   settings_display_closed_statuses: 'Pokaż statusy z atrybutem "closed"'
-  settings_display_child_projects_tasks: 'Wyświetlaj zadania projektów podrzędnych'
+  settings_display_child_projects_tasks: "Wyświetlaj zadania projektów podrzędnych"
+  settings_display_open_projects_only: 'Wyświetlaj tylko projekty ze statusem "otwarte"'
   settings_display_minimized_closed_issue_cards: 'Wyświetlaj karty zadań z atrybutem "closed" zminimalizowane'
   settings_enable_drag_and_drop: 'Zmiana statusu poprzez "Drag and drop"'
   settings_generate_colors: "Wygeneruj kolory"

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -3,10 +3,11 @@ pt_BR:
   settings_header_statuses: "Cores das Situações"
   settings_header_projects: "Cores dos Projetos"
   settings_header_other: "Outro"
-  settings_use_drop_down_menu: 'Use um menu drop-down para escolha de projeto'
+  settings_use_drop_down_menu: "Use um menu drop-down para escolha de projeto"
   settings_display_closed_statuses: 'Mostrar tarefas com situação "FECHADO"'
-  settings_display_child_projects_tasks: 'Mostrar tarefas filhas dos projetos'
-  settings_display_minimized_closed_issue_cards: 'Mostrar minizados os cartões de tarefas fechadas'
+  settings_display_child_projects_tasks: "Mostrar tarefas filhas dos projetos"
+  settings_display_open_projects_only: 'Exibir apenas projetos com status "aberto"'
+  settings_display_minimized_closed_issue_cards: "Mostrar minizados os cartões de tarefas fechadas"
   settings_enable_drag_and_drop: 'Mudar situação com "Drag and drop"'
   settings_generate_colors: "Gerar as cores"
   executor_not_set: "Não definido"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -3,9 +3,10 @@ ru:
   settings_header_statuses: "Цвета статусов"
   settings_header_projects: "Цвета проектов"
   settings_header_other: "Разное"
-  settings_use_drop_down_menu: 'Использовать выпадающий список для выбора проекта'
+  settings_use_drop_down_menu: "Использовать выпадающий список для выбора проекта"
   settings_display_closed_statuses: 'Отображать "закрытые" статусы'
-  settings_display_child_projects_tasks: 'Отображать задачи дочерних проектов'
+  settings_display_child_projects_tasks: "Отображать задачи дочерних проектов"
+  settings_display_open_projects_only: "Отображать только проекты со статусом «открыто»"
   settings_display_minimized_closed_issue_cards: 'Отображать свернутые карточки "закрытых" задач'
   settings_enable_drag_and_drop: '"Drag and drop" изменение статуса'
   settings_generate_colors: "Сгенерировать цвета"

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -3,9 +3,10 @@ sv:
   settings_header_statuses: "Statusfärger"
   settings_header_projects: "Projektfärger"
   settings_header_other: "Övrigt"
-  settings_use_drop_down_menu: 'Använd drop-down-meny för att välja projekt'
+  settings_use_drop_down_menu: "Använd drop-down-meny för att välja projekt"
   settings_display_closed_statuses: 'Visa "stängda"'
-  settings_display_child_projects_tasks: 'Visa underprojekts uppgifter'
+  settings_display_child_projects_tasks: "Visa underprojekts uppgifter"
+  settings_display_open_projects_only: 'Visa endast projekt med status "öppen"'
   settings_display_minimized_closed_issue_cards: 'Visa "stängda" kort minimerade'
   settings_enable_drag_and_drop: '"Drag-och-Släpp" status-hantering'
   settings_generate_colors: "Skapa färger"

--- a/config/locales/ua.yml
+++ b/config/locales/ua.yml
@@ -3,9 +3,10 @@ ua:
   settings_header_statuses: "Кольори статусів"
   settings_header_projects: "Кольори проектів"
   settings_header_other: "Різне"
-  settings_use_drop_down_menu: 'Використовувати випадаючий список для вибору проекту'
+  settings_use_drop_down_menu: "Використовувати випадаючий список для вибору проекту"
   settings_display_closed_statuses: 'Відображати "зачинені" статуси'
-  settings_display_child_projects_tasks: 'Відображати завдання дочірніх проектів'
+  settings_display_child_projects_tasks: "Відображати завдання дочірніх проектів"
+  settings_display_open_projects_only: 'Відображати лише проекти зі статусом "відкрито"'
   settings_display_minimized_closed_issue_cards: 'Відображати згорнуті картки "закритих" завдань'
   settings_enable_drag_and_drop: '"Drag and drop" зміна статусу'
   settings_generate_colors: "Згенерувати кольори"


### PR DESCRIPTION
Adding the option in the settings to display only open projects and their issues.